### PR TITLE
Added past electrical & water data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csv filter=lfs diff=lfs merge=lfs -text

--- a/data/raw/electrical_energy/electrical_energy_2021.csv
+++ b/data/raw/electrical_energy/electrical_energy_2021.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25a3d94b6844f78c07177e8e46b2d6c236d2aa08fda35438aa4c28dba9b4144c
+size 8736940

--- a/data/raw/electrical_energy/electrical_energy_2022.csv
+++ b/data/raw/electrical_energy/electrical_energy_2022.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4095b42abc2d3a229fc0db99cdf116d49b7502b1d756c451587c8a482d5b7876
+size 8822288

--- a/data/raw/electrical_energy/electrical_energy_2023.csv
+++ b/data/raw/electrical_energy/electrical_energy_2023.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8abb3728df21907c90f9200dff10c36e9463fea49f9c5b653c95516b0c37d2d2
+size 8961218

--- a/data/raw/electrical_energy/electrical_energy_2024.csv
+++ b/data/raw/electrical_energy/electrical_energy_2024.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:368fecd8c1cc4ce17ebb819d15cfe89a8db7365adef9186403b73a0b83bb94e5
+size 9077753

--- a/data/raw/electrical_energy/electrical_energy_2025.csv
+++ b/data/raw/electrical_energy/electrical_energy_2025.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b929d9d51c6d4525a0f236c44a7c08d8bd5e2540dd2f46a469e0d60264e1054
+size 8276050

--- a/data/raw/hot_water_energy/hot_water_energy_2021.csv
+++ b/data/raw/hot_water_energy/hot_water_energy_2021.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cff2f3b1fb13af0811c3b34f327a047e45262672f881cb6aaf35b733c2e6359b
+size 7040632

--- a/data/raw/hot_water_energy/hot_water_energy_2022.csv
+++ b/data/raw/hot_water_energy/hot_water_energy_2022.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28b448e359e93aaf1a5c057de5ee320819db2124471624d1fa8fb294fd742cfa
+size 7125670

--- a/data/raw/hot_water_energy/hot_water_energy_2023.csv
+++ b/data/raw/hot_water_energy/hot_water_energy_2023.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a33db2d8df5fe400fcf32b5c7c9628214af26c192251ec6119ceb07a7a0c8b6
+size 6921635

--- a/data/raw/hot_water_energy/hot_water_energy_2024.csv
+++ b/data/raw/hot_water_energy/hot_water_energy_2024.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01bfab0b169f976552dd79a27b939174afc38929efa3f5c93bc51d64c75be9b9
+size 6975185

--- a/data/raw/hot_water_energy/hot_water_energy_2025.csv
+++ b/data/raw/hot_water_energy/hot_water_energy_2025.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a080565f404db12dc7c35e7b7360348fe9c55731c397256922c7804482b4ecc3
+size 310677


### PR DESCRIPTION
## Summary

Added historical SkySpark data (from 2021 to present) for electrical energy data & hot water energy data. 

## Changes

- Added two folders under `\data\raw\`: `electrical_energy` & `hot_water_energy`
- Added `gitattributes` file in order to use GitHub LFS
- Annual data is stored in `csv` format: `electrical_energy_2021.csv`

## Related Issues

Related issue: `#9`

## Notes

- Selected two key variables from the SkySpark dataset: electrical energy and hot water energy.

- Excluded variables such as 'Electrical Power' and 'Hot Water Power', as these represent the product of power and time, which already captures the energy data.

- Omitted 'Gas Volume' and 'Steam Volume' as these metrics are only recorded for a limited number of UBC buildings.

- Weather data is to be collected by @smoskii in a different PR and separate branch.

-  Each file contains 8,760 rows (365 days × 24 hours), as we are capturing measurements for every single hour of the entire year. Also recorded unit for every row is in kilowatt-hour (kWh).

 - TODO: Will need to update README.md file, to let everyone know to install GitHub LFS in order to access the past archived data.
